### PR TITLE
Refine RGB matrix defaults and indicator behavior

### DIFF
--- a/RK75/config.h
+++ b/RK75/config.h
@@ -31,16 +31,10 @@
 
 // Set defaults for LED matrix
 #define RGB_MATRIX_DEFAULT_MODE RGB_MATRIX_SOLID_COLOR
-#define RGB_MATRIX_DEFAULT_HUE 240
-#define RGB_MATRIX_DEFAULT_SAT 255
-#define RGB_MATRIX_DEFAULT_VAL 120
+#define RGB_MATRIX_DEFAULT_HUE 7
+#define RGB_MATRIX_DEFAULT_SAT 191
+#define RGB_MATRIX_DEFAULT_VAL 255
 #define RGB_MATRIX_MAXIMUM_BRIGHTNESS 200
-
-// Enable the RGB Matrix Splash feature
-#define ENABLE_RGB_MATRIX_SOLID_SPLASH
-
-// Optional: Set the duration of the splash animation (in milliseconds)
-#define RGB_MATRIX_SOLID_SPLASH_TIME 2000 // Adjust duration as needed
 
 // Enabling CapsWord activation with both shifts
 #define BOTH_SHIFTS_TURNS_ON_CAPS_WORD

--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -68,6 +68,27 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
 #endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (record->event.pressed) {
+        lazercore_rgb_note_frow_press(record->event.key.row, record->event.key.col);
+
+        switch (keycode) {
+            case QK_NKRO_TOGGLE:
+            case QK_NKRO_ON:
+            case QK_NKRO_OFF:
+                lazercore_rgb_flash_nkro();
+                break;
+            case GAME_MODE:
+                lazercore_rgb_flash_socd();
+                break;
+            case QK_BOOTLOADER:
+                lazercore_rgb_flash_dfu();
+                break;
+            case EE_CLR:
+                lazercore_rgb_flash_eeprom();
+                break;
+        }
+    }
+
     if (!process_type_alchemy(keycode, (char)(keycode - KC_A + 'a'), record->event.pressed)) {
         return false; // Skip further processing if type_alchemy handled the event
     }

--- a/RK75/keymaps/lazercore/rgb_matrix_user.inc
+++ b/RK75/keymaps/lazercore/rgb_matrix_user.inc
@@ -1,29 +1,116 @@
-// Step 1: Declare the custom effect
-RGB_MATRIX_EFFECT(game_mode_effect)
+#include "utils/indicators.h"
+#include "timer.h"
 
-// gggStep 2: Define the effect logic inside the `RGB_MATRIX_CUSTOM_EFFECT_IMPLS` block
-#ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#define LAZERCORE_FROW_FLASH_MS 180
+#define LAZERCORE_GLOBAL_FLASH_MAX_MS 480
 
-// Custom RGB Matrix Game Mode Effect
-static bool game_mode_effect(effect_params_t* params) {
-  // Use limits to ensure we work within the bounds of the available LED matrix
-  RGB_MATRIX_USE_LIMITS(led_min, led_max);
+typedef struct {
+    bool     active;
+    uint16_t started_at;
+} lazercore_led_flash_t;
 
-  // Set background color to #0432b1 for all keys (light pink)
-  for (uint8_t i = led_min; i < led_max; i++) {
-    rgb_matrix_set_color(i, 0x34, 0x01, 0x80);  // Set background for all keys
-  }
-  
-  // Set full brightness for WASD, Space, and Ctrl keys
-  rgb_matrix_set_color(47, 0xFF, 0x00, 0x00); // W
-  rgb_matrix_set_color(51, 0xFF, 0x00, 0x00); // A
-  rgb_matrix_set_color(52, 0xFF, 0x00, 0x00); // S
-  rgb_matrix_set_color(53, 0xFF, 0x00, 0x00); // D
-  // Set full brightness for 1, 2, 3, and 4 keys
+typedef struct {
+    bool     active;
+    uint16_t started_at;
+    uint16_t duration;
+    rgb_t    color;
+} lazercore_global_flash_t;
 
+static lazercore_led_flash_t lazercore_frow_flashes[RGB_MATRIX_LED_COUNT];
+static lazercore_global_flash_t lazercore_global_flash = {0};
 
-  // Check if the effect has finished
-  return rgb_matrix_check_finished_leds(led_max);
+static inline uint8_t lazercore_decay(uint16_t elapsed, uint16_t duration, uint8_t peak) {
+    if (elapsed >= duration || duration == 0) {
+        return 0;
+    }
+    uint16_t remaining = duration - elapsed;
+    return (uint8_t)(((uint32_t)peak * remaining) / duration);
 }
 
-#endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+void lazercore_rgb_note_frow_press(uint8_t row, uint8_t col) {
+    if (row != 0) {
+        return;
+    }
+    uint8_t led = g_led_config.matrix_co[row][col];
+    if (led == NO_LED || led >= RGB_MATRIX_LED_COUNT) {
+        return;
+    }
+
+    lazercore_frow_flashes[led].active     = true;
+    lazercore_frow_flashes[led].started_at = timer_read();
+}
+
+bool lazercore_rgb_get_frow_flash(uint8_t led, rgb_t *out) {
+    if (led >= RGB_MATRIX_LED_COUNT) {
+        return false;
+    }
+
+    lazercore_led_flash_t *flash = &lazercore_frow_flashes[led];
+    if (!flash->active) {
+        return false;
+    }
+
+    uint16_t elapsed = timer_elapsed(flash->started_at);
+    if (elapsed >= LAZERCORE_FROW_FLASH_MS) {
+        flash->active = false;
+        return false;
+    }
+
+    if (out != NULL) {
+        uint8_t intensity = lazercore_decay(elapsed, LAZERCORE_FROW_FLASH_MS, 255);
+        out->r            = intensity;
+        out->g            = intensity;
+        out->b            = intensity;
+    }
+
+    return true;
+}
+
+static void lazercore_start_global_flash(rgb_t color, uint16_t duration) {
+    if (duration > LAZERCORE_GLOBAL_FLASH_MAX_MS) {
+        duration = LAZERCORE_GLOBAL_FLASH_MAX_MS;
+    }
+
+    lazercore_global_flash.active     = true;
+    lazercore_global_flash.started_at = timer_read();
+    lazercore_global_flash.duration   = duration;
+    lazercore_global_flash.color      = color;
+}
+
+bool lazercore_rgb_get_global_flash(rgb_t *out) {
+    if (!lazercore_global_flash.active) {
+        return false;
+    }
+
+    uint16_t elapsed = timer_elapsed(lazercore_global_flash.started_at);
+    if (elapsed >= lazercore_global_flash.duration) {
+        lazercore_global_flash.active = false;
+        return false;
+    }
+
+    if (out != NULL) {
+        uint8_t fade = lazercore_decay(elapsed, lazercore_global_flash.duration, 255);
+        out->r       = (uint8_t)(((uint16_t)lazercore_global_flash.color.r * fade) / 255);
+        out->g       = (uint8_t)(((uint16_t)lazercore_global_flash.color.g * fade) / 255);
+        out->b       = (uint8_t)(((uint16_t)lazercore_global_flash.color.b * fade) / 255);
+    }
+
+    return true;
+}
+
+void lazercore_rgb_flash_nkro(void) {
+    lazercore_start_global_flash((rgb_t){0x30, 0xE0, 0xFF}, 320);
+}
+
+void lazercore_rgb_flash_socd(void) {
+    lazercore_start_global_flash((rgb_t){0xFF, 0x66, 0xCC}, 320);
+}
+
+void lazercore_rgb_flash_dfu(void) {
+    lazercore_start_global_flash((rgb_t){0xFF, 0x80, 0x40}, 420);
+}
+
+void lazercore_rgb_flash_eeprom(void) {
+    lazercore_start_global_flash((rgb_t){0xFF, 0xD4, 0x40}, 420);
+}
+

--- a/RK75/keymaps/lazercore/utils/game_mode.c
+++ b/RK75/keymaps/lazercore/utils/game_mode.c
@@ -11,7 +11,7 @@ void enable_game_mode(void) {
     layer_clear();
     layer_on(0);
     previous_rgb_matrix_mode = rgb_matrix_get_mode();
-    rgb_matrix_mode(RGB_MATRIX_CUSTOM_game_mode_effect);
+    rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
 }
 
 void disable_game_mode(void) {

--- a/RK75/keymaps/lazercore/utils/indicators.c
+++ b/RK75/keymaps/lazercore/utils/indicators.c
@@ -1,77 +1,119 @@
 #include "indicators.h"
 #include "sentence_case.h"
 #include "type_alchemy.h"
-bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
-    uint8_t layer = get_highest_layer(layer_state | default_layer_state);
+#ifdef AUTOCORRECT_ENABLE
+#    include "autocorrect.h"
+#endif
 
-    for (uint8_t i = led_min; i < led_max; i++) {
-        hsv_t global_hsv = rgb_matrix_get_hsv();
+#define LAZERCORE_LED_CAPS 50
+#define LAZERCORE_LED_ENTER 62
+#define LAZERCORE_LED_RSFT 64
+#define LAZERCORE_LED_LGUI 77
+#define LAZERCORE_LED_TYPE_ALCHEMY 20
+#define LAZERCORE_LED_UNICODE 19
+#define LAZERCORE_LED_AUTOCORRECT 18
 
-        if (layer == 0) {
-            // Sentence Case Key Indicator
-            if (is_sentence_case_on() && i == 50) {
-                rgb_matrix_set_color(i, 0xFF, 0x00, 0x00);
-            }
+#define LAZERCORE_FROW_LED_COUNT 14
 
-            // Type Alchemy Key Indicator
-            if (is_type_alchemy_on() && i == 20) {
-                uint8_t unicode_mode = get_unicode_input_mode();
+static const uint8_t lazercore_frow_leds[LAZERCORE_FROW_LED_COUNT] = {
+    21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8,
+};
 
-                // Check the active Unicode input mode and set the color
-                if (unicode_mode == 4) {
-                    rgb_matrix_set_color(i, 0x00, 0xFF, 0x00); // Green for WinCompose
-                } else if (unicode_mode == 1) {
-                    rgb_matrix_set_color(i, 0xFF, 0x00, 0x00); // Red for Linux
-                } else if (unicode_mode == 0) {
-                    rgb_matrix_set_color(i, 0x00, 0x00, 0xFF); // Blue for macOS
-                } else {
-                    rgb_matrix_set_color(i, 0xFF, 0xFF, 0x00); // Yellow for default/unknown
-                }
-            }
-
-            // Autocorrect Enabled? 
-            if (autocorrect_is_enabled() && i == 18){
-                rgb_matrix_set_color(i, 0x00, 0xFF, 0x00); // Green
-            }
-        }
-
-        // Layer 1 Lighting
-        if (layer == 1) {
-            if (i == 6) {
-                rgb_matrix_set_color(i, 0xFF, 0xFF, 0xFF); // White
-            } else if (i == 3 || i == 63) {
-                rgb_matrix_set_color(i, 0xE4, 0x00, 0xFF); // Purple
-            } else if (i == 2 || i == 4) {
-                rgb_matrix_set_color(i, 0xFB, 0x98, 0xFF); // Pink
-            } else if (i == 64) {
-                rgb_matrix_set_color(i, 0xFF, 0x00, 0x12); // Red
-            } else if (i == 50 || i == 19 || i == 20 || i == 18) {
-                rgb_matrix_set_color(i, 0xFF, 0x00, 0x00); // Bright Red
-            } else {
-                hsv_t dimmed_hsv = global_hsv;
-                dimmed_hsv.v = dimmed_hsv.v / 2;
-                rgb_t rgb = hsv_to_rgb(dimmed_hsv);
-                rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-            }
-        }
-
-        // Layer 2 Lighting
-        if (layer == 2) {
-            if (i == 21 || i == 55) {
-                rgb_matrix_set_color(i, 0xFF, 0x00, 0x00); // Bright Red
-            } else {
-                hsv_t dimmed_hsv = global_hsv;
-                dimmed_hsv.v = dimmed_hsv.v / 3;
-                rgb_t rgb = hsv_to_rgb(dimmed_hsv);
-                rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
-            }
+static bool lazercore_is_frow_led(uint8_t led_index) {
+    for (uint8_t i = 0; i < LAZERCORE_FROW_LED_COUNT; ++i) {
+        if (lazercore_frow_leds[i] == led_index) {
+            return true;
         }
     }
+    return false;
+}
 
-    // Layer 3 Audio Visualization
+static rgb_t lazercore_scale_hsv(hsv_t hsv, uint8_t percentage) {
+    hsv_t scaled = hsv;
+    scaled.v = (uint8_t)(((uint16_t)scaled.v * percentage) / 100);
+    return hsv_to_rgb(scaled);
+}
+
+static rgb_t lazercore_make_rgb(uint8_t r, uint8_t g, uint8_t b) {
+    rgb_t color = {r, g, b};
+    return color;
+}
+
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    uint8_t layer = get_highest_layer(layer_state | default_layer_state);
+    bool fn_active = layer_state_is(1);
+
+    hsv_t base_hsv = rgb_matrix_get_hsv();
+    rgb_t dim40 = lazercore_scale_hsv(base_hsv, 40);
+    rgb_t dim60 = lazercore_scale_hsv(base_hsv, 60);
+
+    rgb_t global_flash_color;
+    bool global_flash_active = lazercore_rgb_get_global_flash(&global_flash_color);
+
+    for (uint8_t led = led_min; led < led_max; ++led) {
+        rgb_t color = lazercore_is_frow_led(led) ? dim60 : dim40;
+
+        if (!global_flash_active) {
+            rgb_t flash_color;
+            if (lazercore_rgb_get_frow_flash(led, &flash_color)) {
+                color = flash_color;
+            }
+
+            switch (led) {
+                case LAZERCORE_LED_TYPE_ALCHEMY:
+                    if (is_type_alchemy_on()) {
+                        color = lazercore_make_rgb(0xD6, 0x5F, 0xFF);
+                    } else {
+                        color = dim60;
+                    }
+                    break;
+                case LAZERCORE_LED_UNICODE: {
+                    uint8_t unicode_mode = get_unicode_input_mode();
+                    if (unicode_mode == 4) {  // WinCompose
+                        color = lazercore_make_rgb(0x20, 0xC0, 0xFF);
+                    } else if (unicode_mode == 1) {  // Linux
+                        color = lazercore_make_rgb(0xFF, 0x40, 0x40);
+                    } else if (unicode_mode == 0) {  // macOS
+                        color = lazercore_make_rgb(0x40, 0x40, 0xFF);
+                    } else {
+                        color = dim60;
+                    }
+                    break;
+                }
+#ifdef AUTOCORRECT_ENABLE
+                case LAZERCORE_LED_AUTOCORRECT:
+                    if (autocorrect_is_enabled()) {
+                        color = lazercore_make_rgb(0x40, 0xFF, 0x80);
+                    }
+                    break;
+#endif
+                case LAZERCORE_LED_CAPS:
+                    if (is_sentence_case_on()) {
+                        color = lazercore_make_rgb(0xFF, 0xC4, 0x60);
+                    }
+                    break;
+                case LAZERCORE_LED_LGUI:
+                    color = keymap_config.no_gui ? lazercore_make_rgb(0xFF, 0x40, 0x40)
+                                                 : lazercore_make_rgb(0x40, 0xCC, 0xFF);
+                    break;
+                default:
+                    break;
+            }
+
+            if (fn_active && (led == LAZERCORE_LED_ENTER || led == LAZERCORE_LED_RSFT)) {
+                color = lazercore_make_rgb(0x40, 0x80, 0xFF);
+            }
+        } else {
+            color = global_flash_color;
+        }
+
+        rgb_matrix_set_color(led, color.r, color.g, color.b);
+    }
+
     if (layer == 3) {
         handle_audio_viz(led_min, led_max);
     }
 
     return false;
 }
+

--- a/RK75/keymaps/lazercore/utils/indicators.h
+++ b/RK75/keymaps/lazercore/utils/indicators.h
@@ -3,3 +3,12 @@
 #include QMK_KEYBOARD_H
 #include "rgb_matrix.h"
 #include "audio_viz.h"
+
+void lazercore_rgb_note_frow_press(uint8_t row, uint8_t col);
+void lazercore_rgb_flash_nkro(void);
+void lazercore_rgb_flash_socd(void);
+void lazercore_rgb_flash_dfu(void);
+void lazercore_rgb_flash_eeprom(void);
+bool lazercore_rgb_get_frow_flash(uint8_t led, rgb_t *out);
+bool lazercore_rgb_get_global_flash(rgb_t *out);
+


### PR DESCRIPTION
## Summary
- set the RGB matrix defaults to the #ff5f40 palette and remove the splash startup effect
- rewrite the indicator routine to apply 40%/60% dimming, Fn highlights, and persistent Win/Sentence Case colours
- add reusable flash state helpers for the F-row and NKRO/SOCD/DFU/EEPROM events and trigger them from the keymap while keeping game mode on solid colour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d938b2d2bc832c9d572e8446ff672b