### PR TITLE
Ensure RK75 NKRO macro expands to a boolean

### DIFF
--- a/RK75/config.h
+++ b/RK75/config.h
@@ -39,5 +39,10 @@
 // Enabling CapsWord activation with both shifts
 #define BOTH_SHIFTS_TURNS_ON_CAPS_WORD
 
+#ifdef NKRO_DEFAULT_ON
+#    undef NKRO_DEFAULT_ON
+#endif
+#define NKRO_DEFAULT_ON true
+
 // Default debounce time
 #define DEBOUNCE 5


### PR DESCRIPTION
## Summary
- undefine and redefine `NKRO_DEFAULT_ON` in `RK75/config.h` so the macro always expands to a valid boolean value

## Testing
- not run (qmk CLI is not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d95b560074832cb84d32c8ae22903e