### PR TITLE
Align VIA function layers and adjust lighting feedback

### DIFF
--- a/RK75/keymaps/lazercore/keymap.c
+++ b/RK75/keymaps/lazercore/keymap.c
@@ -16,15 +16,14 @@ enum layer_names {
 };
 
 enum custom_keycodes {
-    RSFT_L2 = SAFE_RANGE,
-    RENTER_L3,
+    WINLOCK_TG = SAFE_RANGE,
+    SENTENCE_CASE_TG,
+    NKRO_TOGGLE_KEY,
+    SOCD_MODE_NEXT,
+    DFU_MODE_KEY,
+    EEPROM_CLEAR_KEY,
 };
 
-static bool fn_held = false;
-static bool right_shift_pressed = false;
-static bool right_enter_pressed = false;
-static bool shift_layer_held = false;
-static bool enter_layer_held = false;
 static bool dfu_pending = false;
 static uint16_t dfu_request_timer = 0;
 static uint8_t socd_mode = 0;  // 0: Neutralize, 1: Last wins, 2: First wins
@@ -101,8 +100,8 @@ KC_EQL,   KC_BSPC,  KC_DEL,
         KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,
 KC_RBRC,  KC_BSLS,  KC_PGUP,
         KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,
-          RENTER_L3,   KC_PGDN,
-        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  RSFT_L2,
+          KC_ENT,   KC_PGDN,
+        KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,
           KC_UP,
         KC_LCTL,  KC_LGUI,  KC_LALT,                      KC_SPC,                                 KC_RALT,  MO(_FN),
 KC_LEFT,  KC_DOWN,  KC_RGHT
@@ -115,11 +114,11 @@ _______,  _______,  _______,
 _______,   _______,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,   _______,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
-          _______,   _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        SENTENCE_CASE_TG, _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+          MO(_ENTER),   _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  MO(_SHIFT),
           _______,
-        _______,  _______,  _______,                      _______,                                 _______,  _______,
+        _______,  WINLOCK_TG,  _______,                      _______,                                 _______,  _______,
 _______,  _______,  _______
         ),
 
@@ -128,9 +127,9 @@ _______,  _______,  _______
 _______,  _______,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,   _______,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        _______,  _______,  SOCD_MODE_NEXT,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,   _______,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        _______,  _______,  _______,  _______,  _______,  _______,  NKRO_TOGGLE_KEY,  _______,  _______,  _______,  _______,  _______,
           _______,   _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
           _______,
@@ -139,9 +138,9 @@ _______,  _______,  _______
         ),
 
     [_ENTER] = LAYOUT(
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        DFU_MODE_KEY,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,  _______,  _______,
-        _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
+        _______,  _______,  _______,  EEPROM_CLEAR_KEY,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,   _______,  _______,
         _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,  _______,
 _______,   _______,  _______,
@@ -180,110 +179,34 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
 };
 #endif
 
-static void set_shift_layer(bool active) {
-    if (shift_layer_held == active) {
-        return;
-    }
-    shift_layer_held = active;
-    indicators_set_layer2(active);
-    if (active) {
-        layer_on(_SHIFT);
-    } else {
-        layer_off(_SHIFT);
-    }
-}
-
-static void set_enter_layer(bool active) {
-    if (enter_layer_held == active) {
-        return;
-    }
-    enter_layer_held = active;
-    indicators_set_layer3(active);
-    if (active) {
-        layer_on(_ENTER);
-    } else {
-        layer_off(_ENTER);
-    }
+layer_state_t layer_state_set_user(layer_state_t state) {
+    indicators_set_fn(layer_state_is(_FN));
+    indicators_set_layer2(layer_state_is(_SHIFT));
+    indicators_set_layer3(layer_state_is(_ENTER));
+    return state;
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-    if (keycode == MO(_FN)) {
-        fn_held = record->event.pressed;
-        indicators_set_fn(fn_held);
-        if (fn_held) {
-            if (right_shift_pressed) {
-                set_shift_layer(true);
-            }
-            if (right_enter_pressed) {
-                set_enter_layer(true);
-            }
-        } else {
-            if (shift_layer_held) {
-                set_shift_layer(false);
-            }
-            if (enter_layer_held) {
-                set_enter_layer(false);
-            }
-        }
-    }
-
-    switch (keycode) {
-        case RSFT_L2:
-            if (record->event.pressed) {
-                right_shift_pressed = true;
-                register_code(KC_RSFT);
-                if (fn_held) {
-                    set_shift_layer(true);
-                }
-            } else {
-                right_shift_pressed = false;
-                unregister_code(KC_RSFT);
-                if (shift_layer_held) {
-                    set_shift_layer(false);
-                }
-            }
-            return false;
-        case RENTER_L3:
-            if (record->event.pressed) {
-                right_enter_pressed = true;
-                register_code(KC_ENT);
-                if (fn_held) {
-                    set_enter_layer(true);
-                }
-            } else {
-                right_enter_pressed = false;
-                unregister_code(KC_ENT);
-                if (enter_layer_held) {
-                    set_enter_layer(false);
-                }
-            }
-            return false;
-    }
-
     if (record->event.pressed) {
-        if (fn_held && keycode == KC_LGUI) {
-            toggle_winlock();
-            return false;
-        }
-        if (fn_held && keycode == KC_CAPS) {
-            sentence_case_toggle();
-            return false;
-        }
-        if (fn_held && shift_layer_held && keycode == KC_N) {
-            toggle_nkro();
-            return false;
-        }
-        if (fn_held && shift_layer_held && keycode == KC_S) {
-            cycle_socd_mode();
-            return false;
-        }
-        if (fn_held && enter_layer_held && keycode == KC_ESC) {
-            arm_dfu_reset();
-            return false;
-        }
-        if (fn_held && enter_layer_held && keycode == KC_E) {
-            clear_eeprom_with_feedback();
-            return false;
+        switch (keycode) {
+            case WINLOCK_TG:
+                toggle_winlock();
+                return false;
+            case SENTENCE_CASE_TG:
+                sentence_case_toggle();
+                return false;
+            case NKRO_TOGGLE_KEY:
+                toggle_nkro();
+                return false;
+            case SOCD_MODE_NEXT:
+                cycle_socd_mode();
+                return false;
+            case DFU_MODE_KEY:
+                arm_dfu_reset();
+                return false;
+            case EEPROM_CLEAR_KEY:
+                clear_eeprom_with_feedback();
+                return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- map the FN, Shift, and Enter layers to the actual shortcuts so VIA shows the intended win lock, sentence case, NKRO, SOCD, DFU, and EEPROM actions
- simplify layer handling logic and ensure the custom keycodes trigger the existing features without leaving Enter stuck
- dim the RGB matrix when secondary layers are active while keeping the relevant function keys highlighted

## Testing
- `qmk compile -kb RK75 -km lazercore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d97795e4e0832cb5e4a00fe89603d3